### PR TITLE
Supress warning C4800 on MSVC 2015.3

### DIFF
--- a/core/api.cpp
+++ b/core/api.cpp
@@ -148,7 +148,7 @@ namespace oidn {
     OIDN_TRY
       checkHandle(hDevice);
       OIDN_LOCK(device);
-      return device->get1i(name);
+      return device->get1i(name) != 0;
     OIDN_CATCH(device)
     return false;
   }
@@ -335,7 +335,7 @@ namespace oidn {
     OIDN_TRY
       checkHandle(hFilter);
       OIDN_LOCK(filter);
-      return filter->get1i(name);
+      return filter->get1i(name) != 0;
     OIDN_CATCH(filter)
     return false;
   }

--- a/core/autoencoder.cpp
+++ b/core/autoencoder.cpp
@@ -44,9 +44,9 @@ namespace oidn {
   void AutoencoderFilter::set1i(const std::string& name, int value)
   {
     if (name == "hdr")
-      hdr = value;
+      hdr = value != 0;
     else if (name == "srgb")
-      srgb = value;
+      srgb = value != 0;
 
     dirty = true;
   }

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -120,7 +120,7 @@ namespace oidn {
     if (name == "numThreads")
       numThreads = value;
     else if (name == "setAffinity")
-      setAffinity = value;
+      setAffinity = value != 0;
 
     dirty = true;
   }

--- a/examples/denoise.cpp
+++ b/examples/denoise.cpp
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
     if (numThreads > 0)
       device.set("numThreads", numThreads);
     if (setAffinity >= 0)
-      device.set("setAffinity", (bool)setAffinity);
+      device.set("setAffinity", setAffinity != 0);
     device.commit();
 
     oidn::FilterRef filter = device.newFilter("RT");


### PR DESCRIPTION
Visual studio issue a (perfomance) warning when you shoehorn an int
inside a bool. This patch fixes those warnings by explicitely checking
the int values against 0, thus producing a bool. (I always thought C4800
was a bit silly to be honest)

This makes the code a tiny bit cleaner (state the bool conversion
explicitly), while not actually changing the generated code:

https://godbolt.org/z/JANbo-