### PR TITLE
Fix #include <windows.h> for case-senstive cross-compilation.

### DIFF
--- a/common/platform.h
+++ b/common/platform.h
@@ -10,7 +10,7 @@
   #if !defined(NOMINMAX)
     #define NOMINMAX
   #endif
-  #include <Windows.h>
+  #include <windows.h>
 #elif defined(__APPLE__)
   #include <sys/sysctl.h>
 #endif


### PR DESCRIPTION
Fixes "common/platform.h:22:12: fatal error: Windows.h: No such file or directory" error when trying to cross-compile for Windows using [mingw-64](http://mingw-w64.org/) compiler on Linux, because on Linux filenames are case-sensitive.