### PR TITLE
Adding support for Apple silicon and optional support for Apple BNNS API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,43 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 # CMake macros
 include(oidn_macros)
 
+
+option(OIDN_BNNS "use Accelrate's framework for convolutions and pooling layers" OFF)
+option(APPLE_SILICON "build for apple silicon ARM based products, using Accelerate framework for NN operations" OFF)
+
+if (APPLE AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+  set(APPLE_SILICON ON)
+  set(OIDN_BNNS ON)
+  message(STATUS "Building OIDN library using BNNS API in Accelerate framework For Apple Silicon")
+endif()
+
+
+
+
+if (APPLE AND OIDN_BNNS)
+  # check for minimal Apple SDK requirements
+
+  if (NOT IOS)
+    set(SDK_VERSION_COMMAND  xcrun -sdk  macosx --show-sdk-version)
+    set(SDK_TARGET 11.0)
+  else()
+    set(SDK_VERSION_COMMAND  xcrun -sdk  iphoneos --show-sdk-version)
+    set(SDK_TARGET 14.0)
+  endif()
+  execute_process(COMMAND  ${SDK_VERSION_COMMAND}
+                  OUTPUT_VARIABLE SDK_VERSION
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if (SDK_VERSION VERSION_LESS SDK_TARGET)
+    message(FATAL_ERROR "Needs Apple SDK version " ${SDK_TARGET} " or above to use BNNS, current SDK version " ${SDK_VERSION})
+  endif()
+  add_definitions(-DUSE_BNNS)
+  add_link_options(-framework Accelerate)
+  if (CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS SDK_TARGET)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
+  endif()
+endif()
+
 # Build as shared or static library
 option(OIDN_STATIC_LIB "Build Intel(R) Open Image Denoise as a static library.")
 mark_as_advanced(CLEAR OIDN_STATIC_LIB)
@@ -86,7 +123,12 @@ include(oidn_platform)
 include(oidn_dnnl)
 
 # ISPC
-set(OIDN_ISPC_TARGET_LIST sse4-i32x8;avx2-i32x8;avx512skx-i32x16)
+if (NOT APPLE_SILICON)
+  set(OIDN_ISPC_TARGET_LIST sse4-i32x8;avx2-i32x8;avx512skx-i32x16)
+else()
+  set(OIDN_ISPC_TARGET_LIST neon-i32x8)
+endif()
+
 set(OIDN_ISPC_ADDRESSING 64)
 include(oidn_ispc)
 
@@ -142,6 +184,14 @@ set(CORE_SOURCES
   core/unet.cpp
   core/upsample.h
 )
+
+if (OIDN_BNNS)
+  set(CORE_SOURCES ${CORE_SOURCES}
+     bnns/bnns_network.h
+     bnns/bnns_network.cpp
+     bnns/bnns_node.h
+  )
+endif()
 
 set(CORE_SOURCES_ISPC
   core/image.ih

--- a/apps/catch.hpp
+++ b/apps/catch.hpp
@@ -7878,7 +7878,16 @@ namespace Catch {
 
 #ifdef CATCH_PLATFORM_MAC
 
-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+// use inline assembler
+#if defined(__i386__) || defined(__x86_64__)
+    #define CATCH_TRAP()  __asm__("int $3")
+#elif defined(__aarch64__)
+    #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+#elif defined(__arm__) && !defined(__thumb__)
+    #define CATCH_TRAP()  __asm__(".inst 0xe7f001f0")
+#elif defined(__arm__) &&  defined(__thumb__)
+    #define CATCH_TRAP()  __asm__(".inst 0xde01")
+#endif
 
 #elif defined(CATCH_PLATFORM_IPHONE)
 

--- a/apps/oidnBenchmark.cpp
+++ b/apps/oidnBenchmark.cpp
@@ -241,11 +241,11 @@ int main(int argc, char* argv[])
       else
         throw std::invalid_argument("invalid argument");
     }
-
+#if !defined(__aarch64__)
     // Enable the FTZ and DAZ flags to maximize performance
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
-
+#endif
     // Initialize the device
     DeviceRef device = newDevice();
 

--- a/apps/oidnDenoise.cpp
+++ b/apps/oidnDenoise.cpp
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
 
     if (!refFilename.empty() && numBenchmarkRuns > 0)
       throw std::runtime_error("reference and benchmark modes cannot be enabled at the same time");
-
+#if !defined(__aarch64__)
     // Set MXCSR flags
     if (!refFilename.empty())
     {
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
       _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
       _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
     }
-
+#endif
     // Load the input image
     std::shared_ptr<ImageBuffer> color, albedo, normal;
     std::shared_ptr<ImageBuffer> ref;

--- a/bnns/bnns_network.cpp
+++ b/bnns/bnns_network.cpp
@@ -1,0 +1,200 @@
+#include "bnns_network.h"
+#include "bnns_node.h"
+#include "../core/color.h"
+
+#if defined(USE_BNNS)
+
+namespace oidn
+{
+std::shared_ptr<Node> BnnsNetwork::addConv(const std::string& name,
+                              const std::shared_ptr<memory>& src,
+                              const std::shared_ptr<memory>& userDst,
+                              bool relu)
+{
+
+    const auto& W = weightsMap[name + ".weight"];
+    if (W.ndims() != 4 || W.layout != "oihw")
+      throw Exception(Error::InvalidOperation, "invalid convolution weights");
+    auto weights = padWeights(W);
+    memory::dims weightsDims = getMemoryDims(weights);
+
+    // Get and pad the biases
+    const auto& b = weightsMap[name + ".bias"];
+    if (b.ndims() != 1)
+      throw Exception(Error::InvalidOperation, "invalid convolution biases");
+    auto bias = padBias(b);
+    memory::dims biasDims = getMemoryDims(bias);
+
+    memory::dims srcDims = getMemoryDims(src);
+    memory::dims dstDims = srcDims;
+    dstDims[1] = weightsDims[0]; // dstDims[C] = weightsDims[OC]
+
+    std::shared_ptr<memory> dst;
+    if (!userDst)
+      dst = allocMemory(dstDims);
+    else if (getMemoryDims(userDst) == dstDims)
+      dst = userDst;
+    else
+      dst = castMemory(dstDims, userDst);
+
+    BNNSLayerParametersConvolution out = (BNNSLayerParametersConvolution)
+    {
+      .x_stride=1,
+      .y_stride = 1,
+      .x_dilation_stride=1,
+      .y_dilation_stride=1,
+      .x_padding = 1,
+      .y_padding = 1,
+    };
+
+    out.i_desc = (BNNSNDArrayDescriptor){.layout = BNNSDataLayoutImageCHW,
+                                                  .size = {(size_t)srcDims[3], (size_t)srcDims[2], (size_t)srcDims[1]},
+                                                  .stride = {0, 0, 0},
+                                                  .data = NULL, //input data pointer can be NULL during filter create
+                                                  .data_type = BNNSDataTypeFloat32};
+    out.w_desc = (BNNSNDArrayDescriptor){.layout = BNNSDataLayoutConvolutionWeightsOIHW,
+                                                  .size = {3, 3, (size_t)srcDims[1] , (size_t)dstDims[1]},
+                                                  .stride = {0, 0, 0, 0},
+                                                  .data = weights->map_data(),
+                                                  .data_type = BNNSDataTypeFloat32};
+    out.bias = (BNNSNDArrayDescriptor){.layout = BNNSDataLayoutVector,
+                                                .size = {(size_t)dstDims[1]},
+                                                .stride = {0},
+                                                .data = bias->map_data(),
+                                                .data_type = BNNSDataTypeFloat32};
+    out.o_desc = (BNNSNDArrayDescriptor){.layout = BNNSDataLayoutImageCHW,
+                                                  .size = {(size_t)dstDims[3],(size_t)dstDims[2],(size_t)dstDims[1]},
+                                                  .stride = {0, 0, 0},
+                                                  .data = NULL,  //output data pointer can be NULL during filter create
+                                                  .data_type = BNNSDataTypeFloat32};
+    out.activation.function = BNNSActivationFunctionRectifiedLinear;
+
+    if (!relu)
+        out.activation.function = BNNSActivationFunctionIdentity;
+
+    std::shared_ptr<Node> node = std::make_shared<BnnsConvNode>(out,src,dst);
+    nodes.push_back(node);
+    return node;
+}
+
+
+std::shared_ptr<Node> BnnsNetwork::addPool(const std::shared_ptr<memory>& src,
+                                           const std::shared_ptr<memory>& userDst)
+{
+    memory::dims srcDims = getMemoryDims(src);
+    memory::dims dstDims = getPoolDims(srcDims);
+
+    std::shared_ptr<memory> dst;
+    if (!userDst)
+      dst = allocMemory(dstDims);
+    else if (getMemoryDims(userDst) == dstDims)
+      dst = userDst;
+    else
+      dst = castMemory(dstDims, userDst);
+
+    BNNSLayerParametersPooling desc = (BNNSLayerParametersPooling){.pooling_function = BNNSPoolingFunctionMax,
+                                                .k_width = 2,
+                                                .k_height = 2,
+                                                .x_stride = 2,
+                                                .y_stride = 2};
+
+    desc.i_desc = (BNNSNDArrayDescriptor){.layout = BNNSDataLayoutImageCHW,
+        .size = {(size_t)srcDims[3], (size_t)srcDims[2], (size_t)srcDims[1]},
+        .stride = {0, 0, 0},
+        .data = NULL,
+        .data_type = BNNSDataTypeFloat32};
+
+    desc.o_desc = (BNNSNDArrayDescriptor){.layout = BNNSDataLayoutImageCHW,
+                                                  .size = {(size_t)srcDims[3]/2, (size_t)srcDims[2]/2, (size_t)srcDims[1]},
+                                                  .stride = {0, 0, 0},
+                                                  .data = NULL,
+                                                  .data_type = BNNSDataTypeFloat32};
+
+
+    std::shared_ptr<Node> node = std::make_shared<BnnsPoolNode>(desc,src,dst);
+    nodes.push_back(node);
+    return node;
+}
+
+
+std::shared_ptr<Node> BnnsNetwork::addUpsample(const std::shared_ptr<memory>& src,
+                                               const std::shared_ptr<memory>& userDst)
+{
+  memory::dims srcDims = getMemoryDims(src);
+  memory::dims dstDims = getUpsampleDims(srcDims);
+
+  std::shared_ptr<memory> dst;
+  if (!userDst)
+    dst = allocMemory(dstDims);
+  else if (getMemoryDims(userDst) == dstDims)
+    dst = userDst;
+  else
+    dst = castMemory(dstDims, userDst);
+
+  auto node = std::make_shared<BnnsUpsampleNode>(src, dst);
+  nodes.push_back(node);
+  return node;
+}
+
+
+
+std::shared_ptr<Node> BnnsNetwork::addInputReorder(const Image& color,
+                                                   const Image& albedo,
+                                                   const Image& normal,
+                                                   const std::shared_ptr<TransferFunction>& transferFunc,
+                                                   bool hdr,
+                                                   int alignment,
+                                                   const std::shared_ptr<memory>& userDst)
+{
+  assert(color);
+  int inputC = 3;
+  if (albedo) inputC += 3;
+  if (normal) inputC += 3;
+
+  memory::dims srcDims = {1, inputC, color.height, color.width};
+  memory::dims dstDims = getInputReorderDims(srcDims, alignment);
+
+  // Allocate padded memory
+  auto dst = userDst;
+  if (!dst)
+    dst = allocMemory(dstDims);
+
+  auto node = std::make_shared<BnnsInputReorderNode>(color, albedo, normal, dst, transferFunc, hdr);
+  nodes.push_back(node);
+  return node;
+}
+
+
+std::shared_ptr<Node> BnnsNetwork::addOutputReorder(const std::shared_ptr<memory>& src,
+                                                    const std::shared_ptr<TransferFunction>& transferFunc,
+                                                    bool hdr,
+                                                    const Image& output)
+{
+  memory::dims srcDims = getMemoryDims(src);
+  assert(srcDims[1] == K);
+
+  // Push node
+  auto node = std::make_shared<BnnsOutputReorderNode>(src, output, transferFunc, hdr);
+  nodes.push_back(node);
+  return node;
+}
+
+
+
+void BnnsNetwork::execute(Progress& progress)
+{
+  for (size_t i = 0; i < nodes.size(); ++i)
+  {
+    nodes[i]->execute(NULL);
+    progress.update(1);
+  }
+}
+
+
+
+};
+
+#endif
+
+
+

--- a/bnns/bnns_network.h
+++ b/bnns/bnns_network.h
@@ -1,0 +1,49 @@
+
+#include "../core/network.h"
+
+#pragma once
+
+
+#if defined(USE_BNNS)
+namespace oidn {
+class BnnsNetwork : public Network
+{
+protected:
+    memory::format_tag getMemoryFormat() override { return memory::format_tag::nchw; }
+
+public:
+    BnnsNetwork(const Ref<Device>& device, const std::map<std::string, Tensor>& weightsMap)
+                : Network(device, weightsMap)
+                {}
+
+    void execute(Progress& progress) override;
+
+
+    std::shared_ptr<Node> addConv(const std::string& name,
+                                  const std::shared_ptr<memory>& src,
+                                  const std::shared_ptr<memory>& userDst = nullptr,
+                                  bool relu = true) override;
+
+    std::shared_ptr<Node> addPool(const std::shared_ptr<memory>& src,
+                                  const std::shared_ptr<memory>& userDst = nullptr) override;
+
+    std::shared_ptr<Node> addUpsample(const std::shared_ptr<memory>& src,
+                                      const std::shared_ptr<memory>& userDst = nullptr) override;
+
+    std::shared_ptr<Node> addInputReorder(const Image& color,
+                                          const Image& albedo,
+                                          const Image& normal,
+                                          const std::shared_ptr<TransferFunction>& transferFunc,
+                                          bool hdr,
+                                          int alignment,
+                                          const std::shared_ptr<memory>& userDst = nullptr) override;
+
+    std::shared_ptr<Node> addOutputReorder(const std::shared_ptr<memory>& src,
+                                           const std::shared_ptr<TransferFunction>& transferFunc,
+                                           bool hdr,
+                                           const Image& output) override;
+
+};
+};
+#endif
+

--- a/bnns/bnns_node.h
+++ b/bnns/bnns_node.h
@@ -1,0 +1,162 @@
+#include "../core/node.h"
+
+#pragma once
+
+#if defined(USE_BNNS)
+#include <Accelerate/Accelerate.h>
+
+namespace oidn
+{
+class BnnsNode : public Node
+{
+public:
+    std::shared_ptr<memory> getDst() const override { return dst; }
+    void execute(stream *) override
+    {
+        float *s = (float *)src->map_data();
+        float *d = (float *)dst->map_data();
+        BNNSFilterApply(filter, s, d);
+        src->unmap_data(s);
+        dst->unmap_data(d);
+    }
+
+    BnnsNode(std::shared_ptr<memory> asrc, std::shared_ptr<memory>adst) : src(asrc),dst(adst),filter(nullptr) {}
+    ~BnnsNode() override
+    {
+        if (filter) BNNSFilterDestroy(filter);
+    }
+
+protected:
+    std::shared_ptr<memory> src;
+    std::shared_ptr<memory> dst;
+    BNNSFilter filter;
+};
+
+class BnnsConvNode : public BnnsNode
+{
+public:
+    BnnsConvNode(BNNSLayerParametersConvolution desc,std::shared_ptr<memory> asrc, std::shared_ptr<memory>adst) :
+    BnnsNode(asrc,adst)
+    {
+        filter = BNNSFilterCreateLayerConvolution(&desc,nullptr);
+        if (!filter) throw Exception(Error::Unknown, "BNNS Convolution creation failed");
+    }
+};
+
+
+class BnnsUpsampleNode : public BnnsNode
+{
+private:
+public:
+    BnnsUpsampleNode(
+                 const std::shared_ptr<memory>& src,
+                 const std::shared_ptr<memory>& dst)
+    : BnnsNode(src,dst)
+  {  }
+    void execute(stream *) override
+    {
+        memory::dims srcDims = getMemoryDims(src);
+        size_t C = srcDims[1];
+        size_t H = srcDims[2];
+        size_t W = srcDims[3];
+  
+        float *pSrc = (float*)src->map_data();
+        float *pDst = (float*)dst->map_data();
+
+        parallel_nd(C, [&](int c)
+        {
+            for (size_t h=0;h<H;h++)
+            {
+                #pragma unroll(32)
+                for (size_t w=0;w<W;w++)
+                {
+                    float val = pSrc[c*H*W + h*W + w];
+                    pDst[c*H*W*4 + 4*h*W + 2*w] = val;
+                    pDst[c*H*W*4 + 4*h*W + 2*w + 1] = val;
+                    pDst[c*H*W*4 + 4*h*W + 2*W + 2*w] = val;
+                    pDst[c*H*W*4 + 4*h*W + 2*W + 2*w + 1] = val;
+                }
+            }
+        });
+        src->unmap_data(pSrc);
+        dst->unmap_data(pDst);
+    }
+};
+
+
+
+class BnnsPoolNode : public BnnsNode
+{
+private:
+public:
+    BnnsPoolNode(BNNSLayerParametersPooling desc,
+                 const std::shared_ptr<memory>& src,
+                 const std::shared_ptr<memory>& dst)
+    : BnnsNode(src,dst)
+  {
+      filter = BNNSFilterCreateLayerPooling(&desc,nullptr);
+      if (!filter) throw Exception(Error::Unknown, "BNNS pool creation failed");
+  }
+};
+
+
+
+class BnnsInputReorderNode : public InputReorderNode
+{
+public:
+    BnnsInputReorderNode(const Image& srcColor,
+                     const Image& srcAlbedo,
+                     const Image& srcNormal,
+                     const std::shared_ptr<memory>& dst,
+                     const std::shared_ptr<TransferFunction>& transferFunc,
+                     bool hdr)
+                        :
+                        InputReorderNode(srcColor,srcAlbedo,srcNormal,dst,transferFunc,hdr)
+                        {}
+ 
+ 
+    void execute(stream *) override
+    {
+      assert(data.H + data.hSrcBegin <= srcColor.height);
+      assert(data.W + data.wSrcBegin <= srcColor.width);
+      assert(data.H + data.hDstBegin <= data.dst.H);
+      assert(data.W + data.wDstBegin <= data.dst.W);
+
+      parallel_nd(data.dst.H, [&](int hDst)
+      {
+        ispc::InputReorder_kernel_chw(&data, hDst);
+      });
+    }
+};
+
+
+
+
+class BnnsOutputReorderNode : public OutputReorderNode
+{
+
+public:
+    BnnsOutputReorderNode(const std::shared_ptr<memory>& src,
+                          const Image& dst,
+                          const std::shared_ptr<TransferFunction>& transferFunc,
+                          bool hdr)
+    : OutputReorderNode(src,dst,transferFunc,hdr)
+    { }
+
+
+  void execute(stream *) override
+  {
+    assert(data.hSrcBegin + data.H <= data.src.H);
+    assert(data.wSrcBegin + data.W <= data.src.W);
+
+    parallel_nd(data.H, [&](int h)
+    {
+      ispc::OutputReorder_kernel_chw(&data, h);
+    });
+  }
+};
+
+};
+
+
+#endif

--- a/cmake/oidn_dnnl.cmake
+++ b/cmake/oidn_dnnl.cmake
@@ -19,7 +19,8 @@ configure_file(
   "${PROJECT_BINARY_DIR}/mkl-dnn/include/dnnl_version.h"
 )
 
-file(GLOB_RECURSE DNNL_SOURCES
+If (NOT APPLE_SILICON)
+  file(GLOB_RECURSE DNNL_SOURCES
   mkl-dnn/src/common/*.[ch]
   mkl-dnn/src/common/*.[ch]pp
   mkl-dnn/src/cpu/bfloat16.cpp
@@ -62,6 +63,32 @@ file(GLOB_RECURSE DNNL_SOURCES
   mkl-dnn/src/cpu/x64/jit_utils/*.[ch]pp
   mkl-dnn/src/cpu/x64/xbyak/*.h
 )
+else()
+    #add only cpu device resources for arm64 (needed for memory management), no point in adding jit for x86 sources
+  file(GLOB_RECURSE DNNL_SOURCES
+  mkl-dnn/src/common/*.[ch]
+  mkl-dnn/src/common/*.[ch]pp
+  mkl-dnn/src/cpu/cpu_concat.cpp
+  mkl-dnn/src/cpu/cpu_concat_pd.hpp
+  mkl-dnn/src/cpu/cpu_convolution_list.cpp
+  mkl-dnn/src/cpu/cpu_convolution_pd.hpp
+  mkl-dnn/src/cpu/cpu_engine.[ch]pp
+  mkl-dnn/src/cpu/cpu_memory_storage.hpp
+  mkl-dnn/src/cpu/cpu_pooling_list.cpp
+  mkl-dnn/src/cpu/cpu_pooling_pd.hpp
+  mkl-dnn/src/cpu/cpu_primitive.hpp
+  mkl-dnn/src/cpu/cpu_reducer.[ch]pp
+  mkl-dnn/src/cpu/cpu_reorder.cpp
+  mkl-dnn/src/cpu/cpu_reorder_pd.hpp
+  mkl-dnn/src/cpu/cpu_stream.hpp
+  mkl-dnn/src/cpu/cpu_sum.cpp
+  mkl-dnn/src/cpu/platform.[ch]pp
+  mkl-dnn/src/cpu/simple_q10n.hpp
+  mkl-dnn/src/cpu/simple_reorder.hpp
+
+)
+endif()
+
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   file(GLOB DNNL_SOURCES_BIGOBJ

--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -15,8 +15,12 @@ namespace oidn {
       return nullptr;
 
     assert((alignment & (alignment-1)) == 0);
+#if !defined(__arm64__)
     void* ptr = _mm_malloc(size, alignment);
-
+#else
+    void* ptr = aligned_alloc(alignment,size);
+#endif
+    
     if (ptr == nullptr)
       throw std::bad_alloc();
 
@@ -26,7 +30,11 @@ namespace oidn {
   void alignedFree(void* ptr)
   {
     if (ptr)
+#if !defined(__arm64__)
       _mm_free(ptr);
+#else
+      free(ptr);
+#endif
   }
 
   // ---------------------------------------------------------------------------

--- a/common/platform.h
+++ b/common/platform.h
@@ -15,8 +15,13 @@
   #include <sys/sysctl.h>
 #endif
 
+#ifndef __aarch64__
+
 #include <xmmintrin.h>
 #include <pmmintrin.h>
+
+#endif
+
 #include <cstdint>
 #include <cstddef>
 #include <climits>

--- a/core/color.h
+++ b/core/color.h
@@ -59,7 +59,7 @@ namespace oidn {
         transferFunc(transferFunc)
     {}
 
-    void execute(stream& sm) override
+    void execute(stream  *) override
     {
       const float exposure = autoexposure(color);
       //printf("exposure = %f\n", exposure);

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -10,8 +10,10 @@ namespace oidn {
 
   Device::Device()
   {
+#if !defined(__aarch64__)
     if (!mayiuse(sse41))
       throw Exception(Error::UnsupportedHardware, "SSE4.1 support is required at minimum");
+#endif
   }
 
   Device::~Device()
@@ -201,11 +203,15 @@ namespace oidn {
     std::cout << "  Platform: " << getPlatformName() << std::endl;
 
     std::cout << "  Targets :";
+#if !defined(__arm64__)
     if (mayiuse(sse41))       std::cout << " SSE4.1";
     if (mayiuse(avx2))        std::cout << " AVX2";
     if (mayiuse(avx512_core)) std::cout << " AVX512SKX";
     std::cout << " (supported)" << std::endl;
     std::cout << "            SSE4.1 AVX2 AVX512SKX (compile time enabled)" << std::endl;
+#else
+      std::cout << "            NEON" << std::endl;
+#endif
 
     std::cout << "  Tasking :";
     std::cout << " TBB" << TBB_VERSION_MAJOR << "." << TBB_VERSION_MINOR;

--- a/core/input_reorder.h
+++ b/core/input_reorder.h
@@ -13,15 +13,13 @@ namespace oidn {
   // Input reorder node
   class InputReorderNode : public Node
   {
-  private:
+  protected:
     ispc::InputReorder data;
-
     Image srcColor;
     Image srcAlbedo;
     Image srcNormal;
     std::shared_ptr<memory> dst;
     std::shared_ptr<TransferFunction> transferFunc;
-
   public:
     InputReorderNode(const Image& srcColor,
                      const Image& srcAlbedo,
@@ -60,7 +58,7 @@ namespace oidn {
       data.W = W;
     }
 
-    void execute(stream& sm) override
+    void execute(stream *sm) override
     {
       assert(data.H + data.hSrcBegin <= srcColor.height);
       assert(data.W + data.wSrcBegin <= srcColor.width);

--- a/core/input_reorder.ispc
+++ b/core/input_reorder.ispc
@@ -28,6 +28,8 @@ struct InputReorder
   uniform bool hdr;
 };
 
+
+
 inline void storeZero(uniform InputReorder* uniform self, uniform int h, int w, uniform int c)
 {
   set1f(self->dst, h, w, c, 0.f);
@@ -86,6 +88,7 @@ export void InputReorder_kernel(uniform InputReorder* uniform self, uniform int 
       for (uniform int c = 0; c < self->dst.C; ++c)
         storeZero(self, hDst, wDst, c);
     }
+    
 
     // Reorder
     foreach (w = 0 ... self->W)
@@ -131,3 +134,110 @@ export void InputReorder_kernel(uniform InputReorder* uniform self, uniform int 
   }
 }
 
+#ifdef USE_BNNS_CHW
+
+inline void storeZero_chw(uniform InputReorder* uniform self, uniform int h, int w, uniform int c)
+{
+  set1f_chw(self->dst, h, w, c, 0.f);
+}
+
+// Stores a color value
+inline void storeColor_chw(uniform InputReorder* uniform self, uniform int h, int w, uniform int c, vec3f value)
+{
+  // Sanitize
+  value = clamp(nan_to_zero(value), 0.f, self->hdr ? pos_max : 1.f);
+
+  // Apply the transfer function
+  value = self->transferFunc->forward(self->transferFunc, value);
+
+  // Store
+  set3f_chw(self->dst, h, w, c, value);
+}
+
+// Stores an albedo value
+inline void storeAlbedo_chw(uniform InputReorder* uniform self, uniform int h, int w, uniform int c, vec3f value)
+{
+  // Sanitize
+  value = clamp(nan_to_zero(value), 0.f, 1.f);
+
+  // Store
+  set3f_chw(self->dst, h, w, c, value);
+}
+
+// Stores a normal value
+inline void storeNormal_chw(uniform InputReorder* uniform self, uniform int h, int w, uniform int c, vec3f value)
+{
+  // Sanitize
+  value = clamp(nan_to_zero(value), neg_max, pos_max);
+
+  // Normalize
+  value = normalize_safe(value);
+
+  // Transform to [0..1]
+  value = value * 0.5f + 0.5f;
+
+  // Store
+  set3f_chw(self->dst, h, w, c, value);
+}
+
+export void InputReorder_kernel_chw(uniform InputReorder* uniform self, uniform int hDst)
+{
+  const uniform int h = hDst - self->hDstBegin;
+
+  if (h >= 0 && h < self->H)
+  {
+    const uniform int hSrc = h + self->hSrcBegin;
+
+    // Zero pad
+    foreach (wDst = 0 ... self->wDstBegin)
+    {
+      for (uniform int c = 0; c < self->dst.C; ++c)
+        storeZero_chw(self, hDst, wDst, c);
+    }
+    
+
+    // Reorder
+    foreach (w = 0 ... self->W)
+    {
+      const int wSrc = w + self->wSrcBegin;
+      const int wDst = w + self->wDstBegin;
+
+      uniform int c = 0;
+      storeColor_chw(self, hDst, wDst, c, get3f(self->srcColor, hSrc, wSrc));
+      c += 3;
+
+      if (self->srcAlbedo.ptr)
+      {
+        storeAlbedo_chw(self, hDst, wDst, c, get3f(self->srcAlbedo, hSrc, wSrc));
+        c += 3;
+      }
+
+      if (self->srcNormal.ptr)
+      {
+        storeNormal_chw(self, hDst, wDst, c, get3f(self->srcNormal, hSrc, wSrc));
+        c += 3;
+      }
+
+      for (; c < self->dst.C; ++c)
+        storeZero_chw(self, hDst, wDst, c);
+    }
+
+    // Zero pad
+    foreach (wDst = self->W + self->wDstBegin ... self->dst.W)
+    {
+      for (uniform int c = 0; c < self->dst.C; ++c)
+        storeZero_chw(self, hDst, wDst, c);
+    }
+  }
+  else
+  {
+    // Zero pad
+    foreach (wDst = 0 ... self->dst.W)
+    {
+      for (uniform int c = 0; c < self->dst.C; ++c)
+        storeZero_chw(self, hDst, wDst, c);
+    }
+  }
+}
+
+#endif

--- a/core/memory.ih
+++ b/core/memory.ih
@@ -16,6 +16,7 @@ struct Memory
   uniform int W;
 };
 
+
 inline size_t getIndex(uniform Memory& mem, uniform int h, int w, uniform int c)
 {
   return ((size_t)mem.H * (c/K) + h) * ((size_t)mem.W*K) + (size_t)w*K + (c%K);
@@ -44,3 +45,40 @@ inline void set3f(uniform Memory& mem, uniform int h, int w, uniform int c, cons
   set1f(mem, h, w, c+1, value.y);
   set1f(mem, h, w, c+2, value.z);
 }
+
+
+#ifdef USE_BNNS_CHW
+
+inline size_t getIndex_chw(uniform Memory& mem, uniform int h, int w, uniform int c)
+{
+  return c*mem.H*mem.W + h*mem.W + w;
+}
+
+inline float get1f_chw(uniform Memory& mem, uniform int h, int w, uniform int c)
+{
+  return mem.ptr[getIndex_chw(mem, h, w, c)];
+}
+
+inline void set1f_chw(uniform Memory& mem, uniform int h, int w, uniform int c, float value)
+{
+  mem.ptr[getIndex_chw(mem, h, w, c)] = value;
+}
+
+inline vec3f get3f_chw(uniform Memory& mem, uniform int h, int w, uniform int c)
+{
+  return make_vec3f(get1f_chw(mem, h, w, c),
+                    get1f_chw(mem, h, w, c+1),
+                    get1f_chw(mem, h, w, c+2));
+}
+
+inline void set3f_chw(uniform Memory& mem, uniform int h, int w, uniform int c, const vec3f& value)
+{
+  set1f_chw(mem, h, w, c,   value.x);
+  set1f_chw(mem, h, w, c+1, value.y);
+  set1f_chw(mem, h, w, c+2, value.z);
+}
+
+
+
+
+#endif

--- a/core/network.h
+++ b/core/network.h
@@ -24,10 +24,12 @@ namespace oidn {
 
   class Network : public Executable
   {
+  protected:
+    virtual memory::format_tag getMemoryFormat() = 0;
+      
   public:
     Network(const Ref<Device>& device, const std::map<std::string, Tensor>& weightsMap);
 
-    void execute(Progress& progress) override;
     double getWorkAmount() const override;
 
     std::shared_ptr<memory> allocMemory(const memory::dims& dims,
@@ -47,32 +49,32 @@ namespace oidn {
 
     memory::dims getInputReorderDims(const memory::dims& srcDims, int alignment);
 
-    std::shared_ptr<Node> addInputReorder(const Image& color,
-                                          const Image& albedo,
-                                          const Image& normal,
-                                          const std::shared_ptr<TransferFunction>& transferFunc,
-                                          bool hdr,
-                                          int alignment,
-                                          const std::shared_ptr<memory>& userDst = nullptr);
+    virtual std::shared_ptr<Node> addInputReorder(const Image& color,
+                                                  const Image& albedo,
+                                                  const Image& normal,
+                                                  const std::shared_ptr<TransferFunction>& transferFunc,
+                                                  bool hdr,
+                                                  int alignment,
+                                                  const std::shared_ptr<memory>& userDst = nullptr) = 0;
 
-    std::shared_ptr<Node> addOutputReorder(const std::shared_ptr<memory>& src,
-                                           const std::shared_ptr<TransferFunction>& transferFunc,
-                                           bool hdr,
-                                           const Image& output);
+    virtual std::shared_ptr<Node> addOutputReorder(const std::shared_ptr<memory>& src,
+                                                   const std::shared_ptr<TransferFunction>& transferFunc,
+                                                   bool hdr,
+                                                   const Image& output) = 0;
 
     memory::dims getConvDims(const std::string& name, const memory::dims& srcDims);
-    std::shared_ptr<Node> addConv(const std::string& name,
+    virtual std::shared_ptr<Node> addConv(const std::string& name,
                                   const std::shared_ptr<memory>& src,
                                   const std::shared_ptr<memory>& userDst = nullptr,
-                                  bool relu = true);
+                                  bool relu = true) = 0;
 
     memory::dims getPoolDims(const memory::dims& srcDims);
-    std::shared_ptr<Node> addPool(const std::shared_ptr<memory>& src,
-                                  const std::shared_ptr<memory>& userDst = nullptr);
+    virtual std::shared_ptr<Node> addPool(const std::shared_ptr<memory>& src,
+                                          const std::shared_ptr<memory>& userDst = nullptr) = 0;
 
     memory::dims getUpsampleDims(const memory::dims& srcDims);
-    std::shared_ptr<Node> addUpsample(const std::shared_ptr<memory>& src,
-                                      const std::shared_ptr<memory>& userDst = nullptr);
+    virtual std::shared_ptr<Node> addUpsample(const std::shared_ptr<memory>& src,
+                                      const std::shared_ptr<memory>& userDst = nullptr) = 0;
 
     memory::dims getConcatDims(const memory::dims& src1Dims, const memory::dims& src2Dims);
 
@@ -81,12 +83,10 @@ namespace oidn {
 
     void finalize();
 
-  private:
+  protected:
     Ref<Device> device;
     engine eng;
-    stream sm;
     int K;                     // block size
-    memory::format_tag nChwKc; // native blocked format
 
     std::vector<std::shared_ptr<Node>> nodes;
     std::map<std::string, Tensor> weightsMap;
@@ -98,5 +98,67 @@ namespace oidn {
     std::shared_ptr<memory> padWeights(const Tensor& src);
     std::shared_ptr<memory> padBias(const Tensor& src);
   };
+
+
+#if !defined(USE_BNNS)
+class DnnNetwork : public Network
+{
+private:
+    stream sm;
+    memory::format_tag nChwKc; // native blocked format
+protected:
+    memory::format_tag getMemoryFormat() override { return nChwKc; }
+
+public:
+    DnnNetwork(const Ref<Device>& device, const std::map<std::string, Tensor>& weightsMap)
+        : Network(device, weightsMap), sm(eng)
+
+        {
+            if (mayiuse(avx512_core))
+            {
+              K = 16;
+              nChwKc = memory::format_tag::nChw16c;
+            }
+            else
+            {
+              K = 8;
+              nChwKc = memory::format_tag::nChw8c;
+            }
+
+        }
+    
+    void execute(Progress& progress) override;
+
+    
+    std::shared_ptr<Node> addPool(const std::shared_ptr<memory>& src,
+                                  const std::shared_ptr<memory>& userDst = nullptr) override;
+    
+    std::shared_ptr<Node> addConv(const std::string& name,
+                                  const std::shared_ptr<memory>& src,
+                                  const std::shared_ptr<memory>& userDst = nullptr,
+                                  bool relu = true) override;
+    
+    std::shared_ptr<Node> addUpsample(const std::shared_ptr<memory>& src,
+                                      const std::shared_ptr<memory>& userDst = nullptr) override;
+    
+    
+    std::shared_ptr<Node> addInputReorder(const Image& color,
+                                          const Image& albedo,
+                                          const Image& normal,
+                                          const std::shared_ptr<TransferFunction>& transferFunc,
+                                          bool hdr,
+                                          int alignment,
+                                          const std::shared_ptr<memory>& userDst = nullptr) override;
+
+    std::shared_ptr<Node> addOutputReorder(const std::shared_ptr<memory>& src,
+                                           const std::shared_ptr<TransferFunction>& transferFunc,
+                                           bool hdr,
+                                           const Image& output) override;
+};
+
+
+#endif
+
+
 
 } // namespace oidn

--- a/core/node.h
+++ b/core/node.h
@@ -13,7 +13,7 @@ namespace oidn {
   public:
     virtual ~Node() = default;
 
-    virtual void execute(stream& sm) = 0;
+    virtual void execute(stream *sm) = 0;
 
     virtual std::shared_ptr<memory> getDst() const { return nullptr; }
 
@@ -25,6 +25,9 @@ namespace oidn {
       assert(0); // not supported
     }
   };
+
+
+#if !defined(USE_BNNS)
 
   // Node wrapping an MKL-DNN primitive
   class MklNode : public Node
@@ -55,9 +58,9 @@ namespace oidn {
       args.insert(std::make_pair(DNNL_ARG_SCRATCHPAD, *scratchpad));
     }
 
-    void execute(stream& sm) override
+    void execute(stream *sm) override
     {
-      prim.execute(sm, args);
+      prim.execute(*sm, args);
     }
   };
 
@@ -127,6 +130,8 @@ namespace oidn {
     std::shared_ptr<memory> getDst() const override { return dst; }
   };
 
+
+
   // Reorder node
   class ReorderNode : public MklNode
   {
@@ -145,5 +150,14 @@ namespace oidn {
 
     std::shared_ptr<memory> getDst() const override { return dst; }
   };
+
+
+#endif
+
+
+
+
+
+
 
 } // namespace oidn

--- a/core/output_reorder.h
+++ b/core/output_reorder.h
@@ -13,7 +13,7 @@ namespace oidn {
   // Output reorder node
   class OutputReorderNode : public Node
   {
-  private:
+  protected:
     ispc::OutputReorder data;
 
     std::shared_ptr<memory> src;
@@ -53,7 +53,7 @@ namespace oidn {
       data.W = W;
     }
 
-    void execute(stream& sm) override
+    void execute(stream *sm) override
     {
       assert(data.hSrcBegin + data.H <= data.src.H);
       assert(data.wSrcBegin + data.W <= data.src.W);

--- a/core/output_reorder.ispc
+++ b/core/output_reorder.ispc
@@ -50,6 +50,43 @@ export void OutputReorder_kernel(uniform OutputReorder* uniform self, uniform in
       value = min(value, 1.f);
 
     // Store
+    
     set3f(self->dst, hDst, wDst, value);
+
   }
 }
+
+
+#ifdef USE_BNNS_CHW
+
+export void OutputReorder_kernel_chw(uniform OutputReorder* uniform self, uniform int h)
+{
+  const uniform int hSrc = h + self->hSrcBegin;
+  const uniform int hDst = h + self->hDstBegin;
+
+  foreach (w = 0 ... self->W)
+  {
+    const int wSrc = w + self->wSrcBegin;
+    const int wDst = w + self->wDstBegin;
+
+    // Load
+    vec3f value = get3f_chw(self->src, hSrc, wSrc, 0);
+
+    // The CNN output may contain negative values or even NaNs, so it must be sanitized
+    value = clamp(nan_to_zero(value), 0.f, pos_max);
+
+    // Apply the inverse transfer function
+    value = self->transferFunc->inverse(self->transferFunc, value);
+
+    // Sanitize
+    if (!self->hdr)
+      value = min(value, 1.f);
+
+    // Store
+    
+    set3f(self->dst, hDst, wDst, value);
+
+  }
+}
+
+#endif

--- a/core/unet.cpp
+++ b/core/unet.cpp
@@ -13,6 +13,10 @@
 #include "weights/rt_ldr_alb_nrm.h"
 #include "weights/rtlightmap_hdr.h"
 
+#if defined(USE_BNNS)
+#include "../bnns/bnns_network.h"
+#endif
+
 namespace oidn {
 
   // ---------------------------------------------------------------------------
@@ -279,8 +283,12 @@ namespace oidn {
     const auto weightsMap = parseTZA(weights.ptr, weights.size);
 
     // Create the network
-    std::shared_ptr<Network> net = std::make_shared<Network>(device, weightsMap);
-
+#if !defined(USE_BNNS)
+    std::shared_ptr<Network> net = std::make_shared<DnnNetwork>(device, weightsMap);
+#else
+    std::shared_ptr<Network> net = std::make_shared<BnnsNetwork>(device, weightsMap);
+#endif
+      
     // Compute the buffer sizes
     const auto inputDims        = memory::dims({1, inputC, tileH, tileW});
     const auto inputReorderDims = net->getInputReorderDims(inputDims, alignment);   //-> concat1

--- a/core/upsample.h
+++ b/core/upsample.h
@@ -33,7 +33,7 @@ namespace oidn {
       assert(data.dst.W == data.src.W * 2);
     }
 
-    void execute(stream& sm) override
+    void execute(stream *sm) override
     {
       parallel_nd(data.src.C / K, data.src.H, [&](int ck, int h)
       {


### PR DESCRIPTION
MacOS 11.0 (BigSur) have updated support for various neural networks layers via improvements to Apple’s BNNS API’s (https://developer.apple.com/documentation/accelerate/bnns?language=objc). Specifically, 2D convolution+relu and max-pooling layers are now available from BNNS and as a result, OIDN u-Network could be easily implemented using BNNS API's.
The attached patch:
1. Allows OIDN to use BNNS API’s instead on MKL-DNN:
 -  Convolution2D and max-pool layers are calling BNNS services directly
 -  As BNNS uses NCHW data arrangement, new input, output and upscale services were added to support NCHW format
 -  MKL-DNN is still used to manage memory
 -  changes to cmake script to support new modeBNNS with all required versioning checks

2. Allows compilation for Apple silicon based Macs and iPhone/iPad
 -  Removing all files and dependencies of MKL-DNN that are specific for x86_64 platforms from compilation process
 -  target ISPC to generate ios-arm64 object files, which are compatible with Apple silicon Mac and iOS

By default, Intel based Mac system will continue to use MKL-DNN.  When targeting the build for Apple silicon Mac targets (CMAKE_OSX_ARCHITECTURES=arm64), cmake will enable BNNS builds and APPLE_SILICON. x86_64 Mac targets can build the BNNS option by setting OIDN_BNNS cmake boolean.