### PR TITLE
changes for oneapi-spec

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,12 +20,14 @@ ifneq "$(PDOK)" "1"
   $(error You need at least pandoc v2.0)
 endif
 
-all: www doc pdf
+all: www doc pdf spec
 www: $(webpages) www/stylesheet.css $(webimages)
 doc: ../README.md
 pdf: ../readme.pdf
+spec: spec/oidn-spec.rst
+	make -C spec html
 
-.PHONY: all www doc pdf clean realclean
+.PHONY: all www doc pdf clean realclean spec
 
 if_is_devel_then = if [[ "${CI_BUILD_REF_NAME}" == "devel" || (-d ../.git && "`git rev-parse --abbrev-ref HEAD`" == "devel") ]] ; then
 
@@ -69,6 +71,13 @@ wwwimgdir:
 $(process_version) tmp/version ../readme.pdf $(tmptexfiles) tmp/api.md tmp/api_html.md tmp/links.md tmp/images_web.md tmp/images_local_pdf.md tmp/images_local_png.md: | tmpdir
 tmpdir:
 	@mkdir -p tmp
+
+## ----------------------------------------------------------------------------
+## Spec
+## ---------------------------------------------------------------------------
+
+spec/oidn-spec.rst: api.md
+	$(PANDOC) --wrap=none --email-obfuscation=none -f markdown $(filter-out webtemplate.html,$+) -V select_$(basename $(@F)) --to rst -o $@
 
 ## -----------------------------------------------------------------------------
 ## Webpages
@@ -164,7 +173,7 @@ tmp/api.tex: filter-latex.py api.md tmp/links.md tmp/images_local_pdf.md
 ## -----------------------------------------------------------------------------
 
 clean:
-	rm -rf www tmp changelog.md __pycache__
+	rm -rf www tmp changelog.md __pycache__ spec/oidn-spec.rst
 
 realclean: clean
 	rm -irf images

--- a/doc/api.md
+++ b/doc/api.md
@@ -25,7 +25,7 @@ serialized, so the amount of API calls from different threads should be minimize
 To have a quick overview of the C99 and C++11 APIs, see the following
 simple example code snippets.
 
-### C99 API Example
+*C99 API Example*
 
     #include <OpenImageDenoise/oidn.h>
     ...
@@ -58,7 +58,7 @@ simple example code snippets.
     oidnReleaseFilter(filter);
     oidnReleaseDevice(device);
 
-### C++11 API Example
+*C++11 API Example*
 
     #include <OpenImageDenoise/oidn.hpp>
     ...

--- a/doc/spec/Makefile
+++ b/doc/spec/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/spec/conf.py
+++ b/doc/spec/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'oidn'
+copyright = '2021, Intel Corporation'
+author = 'Intel Corporation'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/doc/spec/index.rst
+++ b/doc/spec/index.rst
@@ -1,0 +1,20 @@
+.. OpenImage Denoise documentation master file, created by
+   sphinx-quickstart on Thu Jan 21 10:22:03 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to OpenImage Denoise's documentation!
+=============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   oidn-spec
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/doc/spec/make.bat
+++ b/doc/spec/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
use pandoc to convert md to restructuredtext (rst)

A third level heading was nested directly in the top level. Sphinx does not allow inconsistent nesting so I changed it to bold