### PR TITLE
Fix parameters for import CUDA external memory from shared handle.

### DIFF
--- a/devices/cuda/cuda_external_buffer.cpp
+++ b/devices/cuda/cuda_external_buffer.cpp
@@ -54,9 +54,12 @@ OIDN_NAMESPACE_BEGIN
       throw Exception(Error::InvalidArgument, "external memory type not supported by the device");
     }
 
-    handleDesc.handle.win32.handle = handle;
-    handleDesc.handle.win32.name = name;
+    if (handle)
+      handleDesc.handle.win32.handle = handle;
+    if (name)
+      handleDesc.handle.win32.name = name;
     handleDesc.size = byteSize;
+    handleDesc.flags |= cudaExternalMemoryDedicated;
 
     init(handleDesc);
   }


### PR DESCRIPTION
In CUDAExternalBuffer, there are 2 issues when creating a CUDAExternalBuffer object.
1. If we use a handle instead of a name, the handle's value will be overwritten by name as it's a union struct.
2. Missing flag cudaExternalMemoryDedicated