### PR TITLE
Windows: improve dependency lookup when loading module library.

### DIFF
--- a/core/module.cpp
+++ b/core/module.cpp
@@ -50,7 +50,7 @@ OIDN_NAMESPACE_BEGIN
     // Prevent the system from displaying a message box when the module fails to load
     UINT prevErrorMode = GetErrorMode();
     SetErrorMode(prevErrorMode | SEM_FAILCRITICALERRORS);
-    void* module = LoadLibraryW(path.c_str());
+    void* module = LoadLibraryExW(path.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
     SetErrorMode(prevErrorMode);
   #else
     void* module = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);


### PR DESCRIPTION
Fixes loading of the module library dependencies when OIDN main library is dynamically loaded at runtime, and libraries are not in the executable directory.

e.g., when app dynamically load `OpenImageDenoise.dll` at runtime, using absolute path, ModuleLoader attempts to load `OpenImageDenoise_device_cpu.dll` module, but it fails since `tbb12.dll` is not in the library search path. This change temporary adds the module library directory to the search path to ensure dependencies are loaded correctly.